### PR TITLE
Add regex words (both diacritics sensitive and not)

### DIFF
--- a/skill/src/main/java/org/dicio/skill/standard/word/DiacriticsInsensitiveRegexWord.java
+++ b/skill/src/main/java/org/dicio/skill/standard/word/DiacriticsInsensitiveRegexWord.java
@@ -1,0 +1,36 @@
+package org.dicio.skill.standard.word;
+
+import java.util.regex.Pattern;
+
+public class DiacriticsInsensitiveRegexWord extends StringWord {
+
+    private final Pattern regexPattern;
+
+    /**
+     * A word in a sentence with the indices of all possible subsequent words. When matching, the
+     * word value will be interpreted as a regex, and it will be matched against the input word
+     * with diacritics and accents removed from it (see e.g. CTRL+F -> Match Diacritics in Firefox).
+     * For diacritics sensitive matching see {@link DiacriticsSensitiveRegexWord}.
+     *
+     * @param regex a valid regex to compile and use to check if a NFKD-normalized input word
+     *              matches
+     * @param minimumSkippedWordsToEnd the minimum number of subsequent words that have to be
+     *                                 skipped to reach the end of the sentence. Used in case the
+     *                                 end of input is reached on this word. Capturing groups count
+     *                                 as if two words were skipped.
+     * @param nextIndices the indices of all possible subsequent words in the owning sentence; it
+     *                    must always contain a value; use the length of the word array to represent
+     */
+    public DiacriticsInsensitiveRegexWord(final String regex,
+                                          final int minimumSkippedWordsToEnd,
+                                          final int... nextIndices) {
+        super(minimumSkippedWordsToEnd, nextIndices);
+        this.regexPattern = Pattern.compile(regex);
+    }
+
+    @Override
+    public boolean matches(final String inputWord, final String normalizedInputWord) {
+        // match against the NFKD normalized input word
+        return regexPattern.matcher(normalizedInputWord).matches();
+    }
+}

--- a/skill/src/main/java/org/dicio/skill/standard/word/DiacriticsInsensitiveWord.java
+++ b/skill/src/main/java/org/dicio/skill/standard/word/DiacriticsInsensitiveWord.java
@@ -7,11 +7,11 @@ public final class DiacriticsInsensitiveWord extends StringWord {
     /**
      * A word in a sentence with the indices of all possible subsequent words. When matching,
      * diacritics and accents will not be checked (see e.g. CTRL+F -> Match Diacritics in Firefox).
-     * For diacritics-sensitive matching see {@link DiacriticsSensitiveWord}.
+     * For diacritics sensitive matching see {@link DiacriticsSensitiveWord}.
      *
      * @param normalizedValue the unicode NFKD normalized value for this word. Use
-     *      *                 {@link org.dicio.skill.util.WordExtractor#nfkdNormalizeWord(String)}
-     *      *                 to NFKD normalize a word.
+     *                        {@link org.dicio.skill.util.WordExtractor#nfkdNormalizeWord(String)}
+     *                        to NFKD normalize a word.
      * @param minimumSkippedWordsToEnd the minimum number of subsequent words that have to be
      *                                 skipped to reach the end of the sentence. Used in case the
      *                                 end of input is reached on this word. Capturing groups count

--- a/skill/src/main/java/org/dicio/skill/standard/word/DiacriticsSensitiveRegexWord.java
+++ b/skill/src/main/java/org/dicio/skill/standard/word/DiacriticsSensitiveRegexWord.java
@@ -1,0 +1,35 @@
+package org.dicio.skill.standard.word;
+
+import java.util.regex.Pattern;
+
+public class DiacriticsSensitiveRegexWord extends StringWord {
+
+    private final Pattern regexPattern;
+
+    /**
+     * A word in a sentence with the indices of all possible subsequent words. When matching, the
+     * word value will be interpreted as a regex, and it will be matched against the input word
+     * without removing diacritics and accents from it (see e.g. CTRL+F -> Match Diacritics in
+     * Firefox). For diacritics insensitive matching see {@link DiacriticsInsensitiveRegexWord}.
+     *
+     * @param regex a valid regex to compile and use to check if an input word matches
+     * @param minimumSkippedWordsToEnd the minimum number of subsequent words that have to be
+     *                                 skipped to reach the end of the sentence. Used in case the
+     *                                 end of input is reached on this word. Capturing groups count
+     *                                 as if two words were skipped.
+     * @param nextIndices the indices of all possible subsequent words in the owning sentence; it
+     *                    must always contain a value; use the length of the word array to represent
+     */
+    public DiacriticsSensitiveRegexWord(final String regex,
+                                        final int minimumSkippedWordsToEnd,
+                                        final int... nextIndices) {
+        super(minimumSkippedWordsToEnd, nextIndices);
+        this.regexPattern = Pattern.compile(regex);
+    }
+
+    @Override
+    public boolean matches(final String inputWord, final String normalizedInputWord) {
+        // match against the original input word
+        return regexPattern.matcher(inputWord).matches();
+    }
+}


### PR DESCRIPTION
This PR adds two new classes that extend `WordBase` and use a regex `Pattern` to match against words. In particular, `DiacriticsInsensitiveRegexWord` matches against the normalized input word (i.e. the one with diacritics removed), while `DiacriticsSensitiveRegexWord` matches against the original input word. This PR is used by Stypox/dicio-sentences-compiler#7.